### PR TITLE
Enhance registry to include argument parsing

### DIFF
--- a/test/recipe/test_builder.py
+++ b/test/recipe/test_builder.py
@@ -4,13 +4,13 @@ from wurm_food.recipe.ingredient import RecipeIngredient
 
 
 class TestBuilder(TestBase):
-    def test_recipe_select(self):
+    def test_select_builder(self):
         builder = RecipeBuilder(
             self._kb.get_cooker('oven'),
             self._kb.get_container('pottery bowl'),
             self._kb,
         )
 
-        selector = builder.select('ingredient', RecipeIngredient.from_name_string('corn', self._kb)).build()
+        selector = builder.select('ingredient', 'corn').build()
 
         assert selector.select(self._kb) == [RecipeIngredient.from_name_string('corn', self._kb)]

--- a/test/recipe/test_selector.py
+++ b/test/recipe/test_selector.py
@@ -6,10 +6,9 @@ from wurm_food.recipe.selector.selector import ExactIngredientSelector, Ingredie
 
 class TestSelector(TestBase):
     def test_exact_ingredient_selector(self):
-        selector = ExactIngredientSelector(RecipeIngredient.from_name_string('feta cheese', self._kb), repetitions=2)
+        selector = ExactIngredientSelector(RecipeIngredient.from_name_string('feta cheese', self._kb))
 
         expected_results = [
-            RecipeIngredient.from_name_string('feta cheese', self._kb),
             RecipeIngredient.from_name_string('feta cheese', self._kb),
         ]
 

--- a/wurm_food/recipe/builder/builder.py
+++ b/wurm_food/recipe/builder/builder.py
@@ -2,8 +2,8 @@ from typing import List
 
 from wurm_food.knowledge import Cooker, Container, KnowledgeBase
 from wurm_food.recipe.recipe import Recipe
-from wurm_food.recipe.selector.filter import FILTER_REGISTRY
-from wurm_food.recipe.selector.selector import Selector, SELECTOR_REGISTRY
+from wurm_food.recipe.selector import SELECTOR_REGISTRY, FILTER_REGISTRY
+from wurm_food.recipe.selector.selector import Selector
 
 
 class SelectorBuilder(object):
@@ -40,8 +40,10 @@ class RecipeBuilder(object):
         )
 
     def select(self, name: str, *args, **kwargs) -> SelectorBuilder:
-        selector_cls = SELECTOR_REGISTRY.get(name)
-        selector = selector_cls(*args, **kwargs)
+        entry = SELECTOR_REGISTRY.get(name)
+        if entry.args:
+            args, kwargs = entry.args.parse_args(self._kb, *args, **kwargs)
+        selector = entry.cls(*args, **kwargs)
         builder = SelectorBuilder(selector)
         self._selectors.append(builder)
 

--- a/wurm_food/recipe/selector/__init__.py
+++ b/wurm_food/recipe/selector/__init__.py
@@ -1,1 +1,2 @@
-from .selector import SELECTOR_REGISTRY
+from .registry import SELECTOR_REGISTRY
+from .registry import FILTER_REGISTRY

--- a/wurm_food/recipe/selector/filter.py
+++ b/wurm_food/recipe/selector/filter.py
@@ -72,19 +72,3 @@ class PrepareIngredientFilter(Filter):
             out_ingredients.append(new_ingredient)
 
         return out_ingredients
-
-
-class FilterRegistry(object):
-    def __init__(self):
-        self._filters = {}
-
-    def register_filter(self, name: str, filter: Filter):
-        if name in self._filters:
-            raise KeyError("{} is already registered as a filter".format(name))
-
-        self._filters[name] = filter
-
-FILTER_REGISTRY = FilterRegistry()
-FILTER_REGISTRY.register_filter('uniform_sample', UniformSampleFilter)
-FILTER_REGISTRY.register_filter('prepare', PrepareIngredientFilter)
-FILTER_REGISTRY.register_filter('dedup', DedupFilter)

--- a/wurm_food/recipe/selector/registry.py
+++ b/wurm_food/recipe/selector/registry.py
@@ -1,0 +1,118 @@
+from abc import ABC, abstractmethod
+from typing import Any, List, NamedTuple, Union, Dict, Optional
+
+from wurm_food.knowledge import KnowledgeBase
+from wurm_food.recipe.ingredient import RecipeIngredient
+from wurm_food.recipe.selector.filter import UniformSampleFilter, PrepareIngredientFilter, DedupFilter
+from wurm_food.recipe.selector.selector import IngredientCategorySelector, ExactIngredientSelector, CombineSelector, \
+    Selector
+
+
+class RegistryArg(ABC):
+    @abstractmethod
+    def parse_arg(self, arg: Any, kb: KnowledgeBase) -> Any:
+        raise NotImplementedError()
+
+
+class SelectorRegistryArgDescriptor(object):
+    def __init__(self, arg_parsers: Dict[Union[int, str], 'RecipeIngredientArg'] = {}, num_args: Optional[int] = None,
+                 allow_missing: bool = True, variadic_parser: Optional[RegistryArg] = None):
+        self._positional_args = {}
+        self._named_args = {}
+        self._num_args = num_args
+        self._allow_missing = allow_missing
+        if arg_parsers and '..' in arg_parsers:
+            self._variadic_parser = arg_parsers['..']
+        else:
+            self._variadic_parser = variadic_parser
+
+        if arg_parsers:
+            for key, value in arg_parsers.items():
+                if isinstance(key, int):
+                    self._positional_args[key] = value
+                else:
+                    self._named_args[key] = value
+
+    def parse_args(self, kb: KnowledgeBase, *args, **kwargs) -> (List[Any], Dict[str, Any]):
+        out_args = [arg for arg in args]
+        out_kw_args = dict(kwargs)
+
+        if self._num_args and self._num_args != len(args) and self._variadic_parser is None:
+            raise ValueError('Got {} args but expected {}'.format(len(args), self._num_args))
+
+        for idx, arg in enumerate(args):
+            if idx in self._positional_args:
+                out_args[idx] = self._positional_args[idx].parse_arg(arg, kb)
+            elif self._variadic_parser:
+                out_args[idx] = self._variadic_parser.parse_arg(arg, kb)
+            elif not self._allow_missing:
+                raise KeyError('Argument #{} is not specified and is required'.format(idx))
+
+        for name, arg in kwargs:
+            if name in self._positional_args:
+                out_kw_args[name] = self._named_args[name].parse_arg(arg, kb)
+            elif not self._allow_missing:
+                raise KeyError('Argument \'{}\' is not specified and is required'.format(name))
+
+        return out_args, out_kw_args
+
+    def num_args(self):
+        return self._num_args
+
+    def positional_args(self):
+        return self._positional_args
+
+    def named_args(self):
+        return self._named_args
+
+
+class SelectorRegistryEntry(NamedTuple):
+    cls: Selector
+    args: SelectorRegistryArgDescriptor
+
+
+class SelectorRegistry(object):
+    def __init__(self):
+        self._selectors = {}
+        self._selector_to_name = {}
+
+    def register_selector(self, name: str, selector_cls: type,
+                          reg_args: Optional[Dict[Union[int, str], RegistryArg]] = None, *args: Any, **kwargs: Any):
+        if name in self._selectors:
+            raise KeyError("{} is already registered as a selector".format(name))
+
+        self._selectors[name] = SelectorRegistryEntry(cls=selector_cls, args=SelectorRegistryArgDescriptor(reg_args, *args, **kwargs))
+        self._selector_to_name[selector_cls] = name
+
+    def get(self, name: str) -> SelectorRegistryEntry:
+        if name not in self._selectors:
+            raise KeyError('{} is not a valid selector'.format(name))
+        return self._selectors[name]
+
+
+class FilterRegistry(SelectorRegistry):
+    def register_filter(self, name: str, selector_cls: type, args: SelectorRegistryArgDescriptor = None):
+        self.register_selector(name, selector_cls, args)
+
+
+class RecipeIngredientArg(RegistryArg):
+    def parse_arg(self, name: str, kb: KnowledgeBase) -> RecipeIngredient:
+        return RecipeIngredient.from_name_string(name, kb)
+
+
+class LiteralArg(RegistryArg):
+    def parse_arg(self, arg: Any, kb: KnowledgeBase) -> Any:
+        return arg
+
+
+SELECTOR_REGISTRY: SelectorRegistry = SelectorRegistry()
+SELECTOR_REGISTRY.register_selector('ingredient', ExactIngredientSelector, {
+    '..': RecipeIngredientArg(),
+}, allow_missing=False)
+SELECTOR_REGISTRY.register_selector('category', IngredientCategorySelector)
+SELECTOR_REGISTRY.register_selector('combine', CombineSelector)
+
+FILTER_REGISTRY: FilterRegistry = FilterRegistry()
+FILTER_REGISTRY.register_filter('uniform_sample', UniformSampleFilter)
+FILTER_REGISTRY.register_filter('prepare', PrepareIngredientFilter)
+FILTER_REGISTRY.register_filter('dedup', DedupFilter)

--- a/wurm_food/recipe/selector/selector.py
+++ b/wurm_food/recipe/selector/selector.py
@@ -22,20 +22,15 @@ class ExactIngredientSelector(Selector):
 
     ## Example
 
-    `ExactIngredientSelector(RecipeIngredient.from_name_string("feta cheese", kb), repetitions=2)`
-    will always select 2 feta cheese ingredients.
+    `ExactIngredientSelector(RecipeIngredient.from_name_string("feta cheese", kb))`
+    will always select feta cheese.
     """
-    def __init__(self, ingredients: Union[RecipeIngredient, List[RecipeIngredient]], repetitions=1):
-        if isinstance(ingredients, list):
-            self._ingredients = ingredients
-        else:
-            self._ingredients = [ingredients]
-        self._repetitions = repetitions
+    def __init__(self, *args: List[RecipeIngredient]):
+        self._ingredients = args
 
     def select(self, kb: KnowledgeBase) -> List[RecipeIngredient]:
         values = []
-        for i in range(0, self._repetitions):
-            values.extend([ingredient.clone() for ingredient in self._ingredients])
+        values.extend([ingredient.clone() for ingredient in self._ingredients])
         return values
 
 
@@ -63,25 +58,3 @@ class CombineSelector(Selector):
         return ingredients
 
 
-class SelectorRegistry(object):
-    def __init__(self):
-        self._selectors = {}
-        self._selector_to_name = {}
-
-    def register_selector(self, name: str, selector: Selector):
-        if name in self._selectors:
-            raise KeyError("{} is already registered as a selector".format(name))
-
-        self._selectors[name] = selector
-        self._selector_to_name[selector] = name
-
-    def get(self, name: str) -> Selector:
-        if name not in self._selectors:
-            raise KeyError('{} is not a valid selector'.format(name))
-        return self._selectors[name]
-
-
-SELECTOR_REGISTRY = SelectorRegistry()
-SELECTOR_REGISTRY.register_selector('ingredient', ExactIngredientSelector)
-SELECTOR_REGISTRY.register_selector('category', IngredientCategorySelector)
-SELECTOR_REGISTRY.register_selector('combine', CombineSelector)


### PR DESCRIPTION
Selector/Filter registry now knows how to parse arguments. This will allow for scripts to easily provide argument strings without worrying about types.